### PR TITLE
add multi-hand validation logic

### DIFF
--- a/README.md
+++ b/README.md
@@ -7,22 +7,30 @@ The goal of this project is to create a set of datatypes and functions that repr
 ## Organization
 The core logic of traditional poker hands is located in `src/Hand.hs`. This module exports four types—`Suit`, `Rank`, `Card`, and `Hand` defined as follows:
 ```haskell
-data Suit = Diamonds | Clubs | Hearts | Spades deriving (Eq, Show)
+data Suit = Diamonds | Clubs | Hearts | Spades deriving (Eq, Enum, Ord, Show)
 
 data Rank = Two
           | Three
           -- etc...
           | King
           | Ace
-          deriving (Eq, Ord, Enum, Show)
+          deriving (Eq, Enum, Ord, Show)
 
-data Card = Card {rank :: Rank, suit :: Suit} deriving (Eq, Show)
+type Card = (Rank, Suit)
 
 data Hand = Hand Card Card Card Card Card deriving (Eq, Show)
 ```
-`Card` and `Hand` are both instances of `Ord`. The implementation of `Ord` that `Hand` provides compares seperate `Hand`s according to the traditional rules of poker
+Hand is an instance of `Ord` whose implementation compares seperate `Hand`s according to the traditional rules of poker.
+
+Hand also exposes a function called validateHands that will check to ensure that no cards are repeated in a given set of hands.
+```haskell
+validateHands :: [Hand] -> Bool
+```
 
 ## Setup
-To build the project, run `make setup` in the top-level directory. This will output an executable file named `chinese-poker` (built from `src/Main.hs`) into the `.cabal-sandbox/bin/` directory.
+To build the project, run `make setup` in the top-level directory.
+
+## Tests
+The tests are written using [Hspec](http://hspec.github.io/). To run the tests type `make test`.
 
 

--- a/chinese-poker.cabal
+++ b/chinese-poker.cabal
@@ -19,6 +19,7 @@ library
       Hand
   build-depends:
       base
+    , Unique >= 0.4.0
   default-language:
       Haskell2010
 

--- a/test/Hand/HandSpec.hs
+++ b/test/Hand/HandSpec.hs
@@ -4,53 +4,53 @@ import Data.List (sort)
 
 import Test.Hspec
 
-import Hand (Suit(..), Rank(..), Card(..), Hand(Hand))
+import Hand (Suit(..), Rank(..), Card(..), Hand(Hand), validateHands)
 
-highCard      = Hand Card {rank = Ace,   suit = Diamonds}
-                     Card {rank = Seven, suit = Hearts}
-                     Card {rank = Five,  suit = Clubs}
-                     Card {rank = Three, suit = Diamonds}
-                     Card {rank = Two,   suit = Spades}
-pair          = Hand Card {rank = Ace,   suit = Clubs}
-                     Card {rank = Ace,   suit = Diamonds}
-                     Card {rank = Nine,  suit = Hearts}
-                     Card {rank = Six,   suit = Spades}
-                     Card {rank = Four,  suit = Diamonds}
-twoPair       = Hand Card {rank = King,  suit = Hearts}
-                     Card {rank = King,  suit = Spades}
-                     Card {rank = Jack,  suit = Clubs}
-                     Card {rank = Jack,  suit = Diamonds}
-                     Card {rank = Nine,  suit = Diamonds}
-trips         = Hand Card {rank = Queen, suit = Spades}
-                     Card {rank = Queen, suit = Hearts}
-                     Card {rank = Queen, suit = Diamonds}
-                     Card {rank = Five,  suit = Spades}
-                     Card {rank = Nine,  suit = Clubs}
-straight      = Hand Card {rank = Queen, suit = Spades}
-                     Card {rank = Jack,  suit = Diamonds}
-                     Card {rank = Ten,   suit = Clubs}
-                     Card {rank = Nine,  suit = Spades}
-                     Card {rank = Eight, suit = Hearts}
-flush         = Hand Card {rank = King,  suit = Spades}
-                     Card {rank = Jack,  suit = Spades}
-                     Card {rank = Nine,  suit = Spades}
-                     Card {rank = Seven, suit = Spades}
-                     Card {rank = Three, suit = Spades}
-fullHouse     = Hand Card {rank = King,  suit = Hearts}
-                     Card {rank = King,  suit = Diamonds}
-                     Card {rank = King,  suit = Spades}
-                     Card {rank = Five,  suit = Hearts}
-                     Card {rank = Five,  suit = Clubs}
-fourOfAKind   = Hand Card {rank = Five,  suit = Diamonds}
-                     Card {rank = Five,  suit = Spades}
-                     Card {rank = Five,  suit = Hearts}
-                     Card {rank = Five,  suit = Clubs}
-                     Card {rank = Three, suit = Hearts}
-straightFlush = Hand Card {rank = Eight, suit = Clubs}
-                     Card {rank = Seven, suit = Clubs}
-                     Card {rank = Six,   suit = Clubs}
-                     Card {rank = Five,  suit = Clubs}
-                     Card {rank = Four,  suit = Clubs}
+highCard      = Hand (Ace,   Diamonds)
+                     (Seven, Hearts)
+                     (Five,  Clubs)
+                     (Three, Diamonds)
+                     (Two,   Spades)
+pair          = Hand (Ace,   Clubs)
+                     (Ace,   Diamonds)
+                     (Nine,  Hearts)
+                     (Six,   Spades)
+                     (Four,  Diamonds)
+twoPair       = Hand (King,  Hearts)
+                     (King,  Spades)
+                     (Jack,  Clubs)
+                     (Jack,  Diamonds)
+                     (Nine,  Diamonds)
+trips         = Hand (Queen, Spades)
+                     (Queen, Hearts)
+                     (Queen, Diamonds)
+                     (Five,  Spades)
+                     (Nine,  Clubs)
+straight      = Hand (Queen, Spades)
+                     (Jack,  Diamonds)
+                     (Ten,   Clubs)
+                     (Nine,  Spades)
+                     (Eight, Hearts)
+flush         = Hand (King,  Spades)
+                     (Jack,  Spades)
+                     (Nine,  Spades)
+                     (Seven, Spades)
+                     (Three, Spades)
+fullHouse     = Hand (King,  Hearts)
+                     (King,  Diamonds)
+                     (King,  Spades)
+                     (Five,  Hearts)
+                     (Five,  Clubs)
+fourOfAKind   = Hand (Five,  Diamonds)
+                     (Five,  Spades)
+                     (Five,  Hearts)
+                     (Five,  Clubs)
+                     (Three, Hearts)
+straightFlush = Hand (Eight, Clubs)
+                     (Seven, Clubs)
+                     (Six,   Clubs)
+                     (Five,  Clubs)
+                     (Four,  Clubs)
 unsortedHandArray = [ trips
                     , fullHouse
                     , highCard
@@ -61,10 +61,15 @@ unsortedHandArray = [ trips
                     , straight
                     , flush
                     ]
+invalidHand   = Hand (Eight, Clubs)
+                     (Eight, Clubs)
+                     (Three, Hearts)
+                     (Five,  Spades)
+                     (Four,  Diamonds)
 
 spec :: Spec
 spec = do
-  describe "absolute" $ do
+  describe "hand implementation of Ord" $ do
     it "correctly sorts a deck of hands" $
       sort unsortedHandArray `shouldBe` [ highCard
                                         , pair
@@ -76,6 +81,18 @@ spec = do
                                         , fourOfAKind
                                         , straightFlush
                                         ]
+  describe "hand validation" $ do
+    it "correctly identifies a valid hand" $
+      validateHands [flush] `shouldBe` True
+
+    it "correctly identifies an invalid hand" $
+      validateHands [invalidHand] `shouldBe` False
+
+    it "correctly identifies two valid hands" $
+      validateHands [highCard, twoPair] `shouldBe` True
+
+    it "correctly identifies two invalid hands" $
+      validateHands [highCard, pair] `shouldBe` False
 
 main :: IO ()
 main = hspec spec


### PR DESCRIPTION
Closes https://github.com/benperez/chinese-poker/issues/5

This PR adds the ability to validate that a given array of hands contains valid cards. This essentially means that there are no repeated cards in the hands.

In order to express this easily, I changed the Card type from a record containing two fields—suit and rank— to a `(Rank, Suit)` type synonym. This allows me to take advantage of the derived `Ord` instances of `Rank` and `Suit` and the built in `Ord` instance of `()` to give an `Ord` instance of `Card`. This allows me to use the `repeated` function in `Data.List.Unique` to easily check for any repeated cards.

@davidchambers
